### PR TITLE
require cmdliner >= 1.0.0

### DIFF
--- a/opam
+++ b/opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/AltGr/opam-ed"
 bug-reports: "https://github.com/AltGr/opam-ed/issues"
 depends: [
   "ocamlfind"
-  "cmdliner"
+  "cmdliner" {>= "1.0.0"}
   "opam-file-format" {>= "2.0.0~beta3"}
 ]
 available: ocaml-version >= "4.03.0"


### PR DESCRIPTION
On my machine with cmdliner 0.9.8, `make` fails with

    File "src/opamEdMain.ml", line 185, characters 4-12:
    Error: Unbound value Arg.conv