### PR TITLE
Bump upper dependency boundry of opam-file-format to 2.2

### DIFF
--- a/opam-ed.opam
+++ b/opam-ed.opam
@@ -10,7 +10,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "ocamlfind"
   "cmdliner" {>= "1.0.0"}
-  "opam-file-format" {>= "2.0.0" & < "2.1"}
+  "opam-file-format" {>= "2.0.0" & < "2.2"}
 ]
 build: [
   [make "COMP=ocamlc" {!ocaml:native}]


### PR DESCRIPTION
Seems to run just fine against opam-file-format 2.1+.